### PR TITLE
BugFix: nltk auto import dependencies for issues #5

### DIFF
--- a/iso4/__init__.py
+++ b/iso4/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
 # -*- coding: UTF-8 -*-
-
 from .abbreviate import abbreviate
+import nltk
+
+nltk.download("wordnet")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="iso4",  # Replace with your own username
-    version="0.0.2",
+    version="0.0.3",
     author="Alex DelPriore",
     author_email="delpriore@stanford.edu",
     description="ISO 4 abbreviation of publication titles in Python.",
@@ -13,7 +13,8 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/adlpr/iso4",
     packages=setuptools.find_packages(),
-    package_data={"": ["LTWA_20170914.json", "LTWA_20170914.tsv", "stopwords.txt", "stopwords_keep_as_last.txt"]},
+    package_data={"": ["LTWA_20170914.json", "LTWA_20170914.tsv",
+                       "stopwords.txt", "stopwords_keep_as_last.txt"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Using this commit, the iso4 library downloads the wordnet using nltk as a dependency.

